### PR TITLE
Hotfix/ssh permission too open

### DIFF
--- a/bucket-production.yml
+++ b/bucket-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/bucket-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/bucket-quality.yml'
 
 deploy:production:
   extends: .deploy

--- a/bucket-quality.yml
+++ b/bucket-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/bucket.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/bucket.yml'
 
 deploy:quality:
   extends: .deploy

--- a/cloudrun-production.yml
+++ b/cloudrun-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/cloudrun-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/cloudrun-quality.yml'
 
 deploy:production:
   extends: deploy:quality

--- a/cloudrun-quality.yml
+++ b/cloudrun-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/cloudrun.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/cloudrun.yml'
 
 deploy:quality:
   extends: .cloudrun:deploy

--- a/dataflow-production.yml
+++ b/dataflow-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/dataflow-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/dataflow-quality.yml'
 
 deploy:production:dataflow:
   extends: .deploy:dataflow

--- a/dataflow-quality.yml
+++ b/dataflow-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/dataflow.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/dataflow.yml'
 
 deploy:quality:dataflow:
   extends: .deploy:dataflow

--- a/docker.yml
+++ b/docker.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/docker.yml'
 
 build:
   stage: build

--- a/helm-multiregion.yml
+++ b/helm-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/helm-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/helm-quality.yml'
 
 # EUROPE
 deploy:production:europe:helm:

--- a/helm-quality.yml
+++ b/helm-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/helm.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/helm.yml'
 
 deploy:quality:helm:
   variables:

--- a/helm-regional.yml
+++ b/helm-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/helm-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/helm-quality.yml'
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/kubernetes-multiregion.yml
+++ b/kubernetes-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/kubernetes-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/kubernetes-quality.yml'
 
 # EUROPE
 deploy:production:europe:image:

--- a/kubernetes-quality.yml
+++ b/kubernetes-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/kubernetes.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/kubernetes.yml'
 
 deploy:quality:image:
   extends: .deploy:image

--- a/kubernetes-regional.yml
+++ b/kubernetes-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/kubernetes-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/kubernetes-quality.yml'
 
 deploy:production:image:
   extends: .deploy:image

--- a/kubernetes-task-production.yml
+++ b/kubernetes-task-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/kubernetes-task-quality.yml'
 
 task:production:
   extends: .task

--- a/kubernetes-task-quality.yml
+++ b/kubernetes-task-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/kubernetes-task.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/kubernetes-task.yml'
 
 task:quality:
   extends: .task

--- a/serverless-multiregion.yml
+++ b/serverless-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/serverless-quality.yml'
 
 # EUROPE
 deploy:production:europe:

--- a/serverless-quality.yml
+++ b/serverless-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/serverless.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/serverless.yml'
 
 deploy:quality:
   extends: .serverless:deploy

--- a/serverless-regional.yml
+++ b/serverless-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/serverless-quality.yml'
 
 deploy:production:
   extends: .serverless:deploy

--- a/ssh-production.yml
+++ b/ssh-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/ssh-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/ssh-quality.yml'
 
 ssh:production:
   extends: .ssh:exec

--- a/ssh-quality.yml
+++ b/ssh-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.1/templates/ssh.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v2.17.2/templates/ssh.yml'
 
 ssh:quality:
   extends: .ssh:exec

--- a/templates/ssh.yml
+++ b/templates/ssh.yml
@@ -16,6 +16,7 @@
       mkdir ~/.ssh
       touch ~/.ssh/known_hosts ~/.ssh/id_rsa
       chmod -R 644 ~/.ssh
+      chmod -R 600 ~/.ssh/id_rsa
 
       echo "${SSH_PRIVATE_KEY}" | base64 -d > ~/.ssh/id_rsa
 


### PR DESCRIPTION
fix the following:
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 Permissions 0644 for '/root/.ssh/id_rsa' are too open.
 It is required that your private key files are NOT accessible by others.
 This private key will be ignored.
```