### PR TITLE
feat: add python linter (not pylint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,19 @@ variables:
   REVIEWDOG_LEVEL: warning # optional, values: info, warning, error
 ```
 
+### Linting python files
+
+```yaml
+include:
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/<REF>/lint-python.yml'
+
+stages:
+  - lint
+
+```
+
+The docker image allows use with reviewdog, like above, but the code has not been added yet. Contributions are welcome
+
 # Unit test stage
 
 ```yaml

--- a/lint-python.yml
+++ b/lint-python.yml
@@ -1,0 +1,27 @@
+lint:python:
+  stage: lint
+  image: linuxbandit/pythonlinter-reviewdog:v1.0.0
+  script:
+    - |
+
+      echo
+      echo "-> Linting code:"
+      echo
+
+      DIRS=( $(ls -F | grep '/' | sed 's|/||') )
+      for dir in "${DIRS[@]}"; do
+        cd "${dir}"
+        FILES=( $(ls *.py) )
+        for file in "${FILES[@]}"; do
+          echo "-> Analysing file ${file}"
+          echo
+          flake8 "${file}"
+          echo
+          echo
+        done
+        cd ..
+      done
+
+      echo
+      echo "-> Code checked!"
+      echo


### PR DESCRIPTION
add a python linter.
wemake-python-styleguide was picked in order to be open to add reviewdog (see readme of reviewdog)