### PR TITLE
Add Helm-Diff Jobs

### DIFF
--- a/bucket-production.yml
+++ b/bucket-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/bucket-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/bucket-quality.yml'
 
 deploy:production:
   extends: .deploy

--- a/bucket-quality.yml
+++ b/bucket-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/bucket.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/bucket.yml'
 
 deploy:quality:
   extends: .deploy

--- a/cloudrun-production.yml
+++ b/cloudrun-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/cloudrun-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/cloudrun-quality.yml'
 
 deploy:production:
   extends: deploy:quality

--- a/cloudrun-quality.yml
+++ b/cloudrun-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/cloudrun.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/cloudrun.yml'
 
 deploy:quality:
   extends: .cloudrun:deploy

--- a/dataflow-production.yml
+++ b/dataflow-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/dataflow-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/dataflow-quality.yml'
 
 deploy:production:dataflow:
   extends: .deploy:dataflow

--- a/dataflow-quality.yml
+++ b/dataflow-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/dataflow.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/dataflow.yml'
 
 deploy:quality:dataflow:
   extends: .deploy:dataflow

--- a/docker.yml
+++ b/docker.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/docker.yml"
 
 build:
   stage: build

--- a/helm-branches.yml
+++ b/helm-branches.yml
@@ -1,5 +1,5 @@
 deploy:quality:helm:branches:
-  image: jobtomelabs/helm-sops-mysql:3.2.0
+  image: jobtomelabs/helm:v3.8.1
   stage: deploy
   environment:
     name: review/$CI_BUILD_REF_NAME
@@ -149,7 +149,7 @@ deploy:quality:helm:branches:
       set +e
       BRANCH_VARS=$( tac /tmp/secrets.yaml | grep -e "DB_USERNAME" -e "DB_PASSWORD" -e "DB_HOST" -e "DB_NAME" -e "DATABASE_URL" | base64)
       set -e
-      
+
       # It is assumed that the quality secret cannot be missing in a feature branch
       touch /tmp/secrets-qa.yaml
 
@@ -168,11 +168,11 @@ deploy:quality:helm:branches:
       fi
 
       envsubst < /tmp/secrets-qa.yaml > /tmp/secrets-qa.yaml.tmp && mv /tmp/secrets-qa.yaml.tmp /tmp/secrets-qa.yaml
-      
+
       set +e
       QUALITY_VARS=$( tac /tmp/secrets-qa.yaml | grep -e "DB_USERNAME" -e "DB_PASSWORD" -e "DB_HOST" -e "DB_NAME" -e "DATABASE_URL" | base64)
       set -e
-      
+
     - |
       # Define db operations (three)
       set +e
@@ -296,7 +296,7 @@ deploy:quality:helm:branches:
       - $CI_COMMIT_REF_NAME !~ /^feat/
 
 stop:quality:
-  image: jobtomelabs/helm-sops-mysql:3.2.0
+  image: jobtomelabs/helm:v3.8.1
   allow_failure: true
   environment:
     name: review/$CI_BUILD_REF_NAME

--- a/helm-multiregion.yml
+++ b/helm-multiregion.yml
@@ -1,9 +1,12 @@
+---
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/helm-quality.yml'
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/helm-diff/helm-quality.yml"
 
 # EUROPE
+
 deploy:production:europe:helm:
   extends: .deploy:production:helm
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_EUROPE}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
@@ -14,9 +17,12 @@ deploy:production:europe:helm:
     ENVIRONMENT: production
     ENVIRONMENT_NAME: production-europe
     ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_EUROPE}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
@@ -26,29 +32,66 @@ deploy:production:europe:helm:
 
 verify:production:europe:
   extends: .verify
+
   stage: verify
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_EUROPE}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
     CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
     NAMESPACE: ${NAMESPACE_PRODUCTION_EUROPE}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_PRODUCTION_EUROPE"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
             exit 1
           fi
       done
+
   only:
     - /^v.+$/i
   except:
     - branches
 
+helm:diff:production:europe:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    DOMAIN: ${DOMAIN_PRODUCTION_EUROPE}
+    SECRET_YAML: ${SECRET_YAML_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_PRODUCTION_EUROPE}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: production-europe
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_EUROPE}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
 # AMERICA
+
 deploy:production:america:helm:
   extends: .deploy:production:helm
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_AMERICA}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
@@ -59,9 +102,12 @@ deploy:production:america:helm:
     ENVIRONMENT: production
     ENVIRONMENT_NAME: production-america
     ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_AMERICA}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
@@ -71,29 +117,66 @@ deploy:production:america:helm:
 
 verify:production:america:
   extends: .verify
+
   stage: verify
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_AMERICA}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
     CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
     NAMESPACE: ${NAMESPACE_PRODUCTION_AMERICA}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_PRODUCTION_AMERICA"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
             exit 1
           fi
       done
+
   only:
     - /^v.+$/i
   except:
     - branches
 
+helm:diff:production:america:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    DOMAIN: ${DOMAIN_PRODUCTION_AMERICA}
+    SECRET_YAML: ${SECRET_YAML_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_PRODUCTION_AMERICA}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: production-america
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_AMERICA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
 # ASIA
+
 deploy:production:asia:helm:
   extends: .deploy:production:helm
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_ASIA}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
@@ -104,9 +187,12 @@ deploy:production:asia:helm:
     ENVIRONMENT: production
     ENVIRONMENT_NAME: production-asia
     ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_ASIA}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
@@ -116,22 +202,57 @@ deploy:production:asia:helm:
 
 verify:production:asia:
   extends: .verify
+
   stage: verify
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_ASIA}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
     CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
     NAMESPACE: ${NAMESPACE_PRODUCTION_ASIA}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_PRODUCTION_ASIA"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
             exit 1
           fi
       done
+
   only:
     - /^v.+$/i
   except:
     - branches
+
+helm:diff:production:asia:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    DOMAIN: ${DOMAIN_PRODUCTION_ASIA}
+    SECRET_YAML: ${SECRET_YAML_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_PRODUCTION_ASIA}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: production-asia
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_ASIA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'

--- a/helm-multiregion.yml
+++ b/helm-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/helm-diff/helm-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/helm-quality.yml"
 
 # EUROPE
 

--- a/helm-only-multiregion.yml
+++ b/helm-only-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/helm-only-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/helm-only-quality.yml"
 
 # EUROPE
 deploy:production:europe:helm:

--- a/helm-only-quality.yml
+++ b/helm-only-quality.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/helm.yml"
 
 deploy:quality:helm:
   variables:

--- a/helm-only-regional.yml
+++ b/helm-only-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/helm-only-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/helm-only-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/helm-quality.yml
+++ b/helm-quality.yml
@@ -1,6 +1,7 @@
+---
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/helm.yml'
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/helm-diff/templates/helm.yml"
 
 deploy:quality:helm:
   variables:
@@ -13,35 +14,73 @@ deploy:quality:helm:
     NAMESPACE: ${NAMESPACE_QUALITY}
     ENVIRONMENT: quality
     ENVIRONMENT_NAME: quality
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_QUALITY" "DOMAIN_QUALITY"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
             exit 1
           fi
       done
+
   only:
     - master
 
 verify:quality:
   extends: .verify
+
   stage: verify
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_QUALITY}
     CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
     CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
     NAMESPACE: ${NAMESPACE_QUALITY}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_QUALITY"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
             exit 1
           fi
       done
+
   only:
     - master
 
+helm:diff:quality:
+  extends: .helm:diff
+
+  variables:
+    CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
+    GOOGLE_KEY: ${GOOGLE_KEY_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    DOMAIN: ${DOMAIN_QUALITY}
+    SECRET_YAML: ${SECRET_YAML_QUALITY}
+    NAMESPACE: ${NAMESPACE_QUALITY}
+    ENVIRONMENT: quality
+    ENVIRONMENT_NAME: quality
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_QUALITY" "DOMAIN_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'

--- a/helm-quality.yml
+++ b/helm-quality.yml
@@ -1,7 +1,7 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/docker.yml"
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/helm-diff/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/helm.yml"
 
 deploy:quality:helm:
   variables:

--- a/helm-regional.yml
+++ b/helm-regional.yml
@@ -1,8 +1,10 @@
+---
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/helm-quality.yml'
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/helm-diff/helm-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
@@ -12,9 +14,12 @@ deploy:production:helm:
     NAMESPACE: ${NAMESPACE_PRODUCTION}
     ENVIRONMENT: production
     ENVIRONMENT_NAME: production
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_PRODUCTION" "DOMAIN_PRODUCTION"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
@@ -24,22 +29,56 @@ deploy:production:helm:
 
 verify:production:
   extends: .verify
+
   stage: verify
+
   variables:
     GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION}
     CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
     CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
     NAMESPACE: ${NAMESPACE_PRODUCTION}
+
   before_script:
     - |
+
       # CHECK VARIABLES PHASE
+
       for var in "GOOGLE_KEY_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_PRODUCTION"; do
           if [ -z "${!var}" ]; then
             echo "Missing '${var}' variable!"
             exit 1
           fi
       done
+
   only:
     - /^v.+$/i
   except:
     - branches
+
+helm:diff:production:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    DOMAIN: ${DOMAIN_PRODUCTION}
+    SECRET_YAML: ${SECRET_YAML_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_PRODUCTION}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: production
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_PRODUCTION" "DOMAIN_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'

--- a/helm-regional.yml
+++ b/helm-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/helm-diff/helm-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/helm-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/kubernetes-multiregion.yml
+++ b/kubernetes-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/kubernetes-quality.yml'
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/kubernetes-quality.yml"
 
 # EUROPE
 deploy:production:europe:image:

--- a/kubernetes-quality.yml
+++ b/kubernetes-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/kubernetes.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/kubernetes.yml'
 
 deploy:quality:image:
   extends: .deploy:image

--- a/kubernetes-regional.yml
+++ b/kubernetes-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/kubernetes-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/kubernetes-quality.yml'
 
 deploy:production:image:
   extends: .deploy:image

--- a/kubernetes-task-multiregion.yml
+++ b/kubernetes-task-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/kubernetes-task-quality.yml'
 
 task:production:europe:
   extends: .task

--- a/kubernetes-task-production.yml
+++ b/kubernetes-task-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/kubernetes-task-quality.yml'
 
 task:production:
   extends: .task

--- a/kubernetes-task-quality.yml
+++ b/kubernetes-task-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/kubernetes-task.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/kubernetes-task.yml'
 
 task:quality:
   extends: .task

--- a/lint-go.yml
+++ b/lint-go.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/lint.yml"
 
 lint:go:
   extends: .lint

--- a/lint-python.yml
+++ b/lint-python.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/lint.yml"
 
 lint:python:
   extends: .lint

--- a/sast.yml
+++ b/sast.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/sast.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/sast.yml"
 
 sast:
   extends: .sast

--- a/serverless-multiregion.yml
+++ b/serverless-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/serverless-quality.yml'
 
 # EUROPE
 deploy:production:europe:

--- a/serverless-quality.yml
+++ b/serverless-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/serverless.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/serverless.yml'
 
 deploy:quality:
   extends: .serverless:deploy

--- a/serverless-regional.yml
+++ b/serverless-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/serverless-quality.yml'
 
 deploy:production:
   extends: .serverless:deploy

--- a/shell-job.yml
+++ b/shell-job.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/lint-shell.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/terraform.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/lint-shell.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/terraform.yml'
 
 job:shell:
   stage: deploy

--- a/ssh-production.yml
+++ b/ssh-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/ssh-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/ssh-quality.yml'
 
 ssh:production:
   extends: .ssh:exec

--- a/ssh-quality.yml
+++ b/ssh-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/ssh.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/ssh.yml'
 
 ssh:quality:
   extends: .ssh:exec

--- a/templates/helm.yml
+++ b/templates/helm.yml
@@ -1,14 +1,20 @@
+---
 .helm:
-  image: jobtomelabs/helm-sops-mysql:3.2.0
+  image: jobtomelabs/helm:v3.8.1
 
 .helm:deploy:
   extends: .helm
+
   stage: deploy
+
   variables:
     GIT_DEPTH: 1
+
   script:
     - &checkvars |
-      #CHECKING VARIABLES PHASE
+
+      # CHECKING VARIABLES PHASE
+
       for var in "GOOGLE_KEY" "CLUSTER_ZONE" "CLUSTER_NAME" "NAMESPACE" "APP_NAME" "PART_OF" "GOOGLE_PROJECT" "CHARTS_URL" "CHART_NAME"; do
           if [ -z "${!var}" ]; then
             echo
@@ -17,8 +23,10 @@
             exit 1
           fi
       done
+
     - &activate |
-      # ACTIVATION  PHASE
+
+      # ACTIVATION PHASE
 
       echo "${GOOGLE_KEY}" > /tmp/key.json
 
@@ -29,7 +37,9 @@
       echo
       echo "-> Google project '${GOOGLE_PROJECT}' configured!"
       echo
+
     - &connect |
+
       # CLUSTER CONNECTION PHASE
 
       gcloud container clusters get-credentials --zone "${CLUSTER_ZONE}" "${CLUSTER_NAME}"
@@ -43,6 +53,7 @@
       echo
 
     - &environment |
+
       # CHECK PATHS
 
       if [ -z "${HELM_DIR}" ]; then
@@ -79,9 +90,10 @@
           fi
       fi
 
-    - |
+    - &secrets-apply |
+
       # SECRETS APPLICATION
-      # Priority: file in repo, then SECRET_YAML
+      # PRIORITY: File in Repository (if any); Otherwise, SECRET_YAML Variable;
 
       if [ ! -f "${HELM_FILES_PATH}/secrets.yaml" ] && [ -z "${SECRET_YAML}" ]; then
         echo
@@ -114,7 +126,9 @@
       fi
 
     - &helmsetup |
+
       # HELM APPLICATION
+
       helm repo add current-repo "${CHARTS_URL}"
       helm repo update
 
@@ -134,11 +148,19 @@
 
     - &helmapply |
 
-      # If it's the First Helm Release, wait 10 minutes for the Ingress to update
+      # HELM INSTALL / UPGRADE
+      # NOTE: If it's the First Helm Release, Wait 10 minutes for the Ingress to update.
+
       WAIT="5s"
+
       helm status "${APP_NAME}" > /dev/null 2>&1 || WAIT="10m"
 
       helm upgrade --install --atomic "${APP_NAME}" "current-repo/${CHART_NAME}" --wait --timeout "${TIMEOUT}" -f /tmp/values.yaml --namespace "${NAMESPACE}" --version ${CHART_VERSION}
+
+      if [ $WAIT == "10m" ]; then
+        echo "Seems like it's the First Release."
+        echo "Waiting 10 Minutes for the Ingress to update .."
+      fi
 
       sleep $WAIT
 
@@ -260,3 +282,69 @@ deploy:quality:helm:
         echo
         exit 1
       fi
+
+.helm:diff:
+  extends: .helm
+
+  stage: test
+
+  variables:
+    GIT_DEPTH: 1
+
+  script:
+    - *checkvars
+    - *activate
+    - *connect
+    - *environment
+    - *helmsetup
+
+    - |
+
+      # HELM DIFF PLUGIN INSTALLATION
+
+      helm plugin uninstall diff
+
+      helm plugin install https://github.com/databus23/helm-diff --version="v3.4.2"
+
+    - |
+
+      # RUN HELM DIFF
+
+      LAST_RELEASE_IMAGE_TAG=$(helm get values "${APP_NAME}" | yq eval-all ".image.tag" -)
+
+      BASE_COMMAND=( helm diff upgrade "${APP_NAME}" "current-repo/${CHART_NAME}" --version="${CHART_VERSION}" --values="/tmp/values.yaml" --set="image.tag=${LAST_RELEASE_IMAGE_TAG}" --namespace="${NAMESPACE}" --allow-unreleased --normalize-manifests --show-secrets=false )
+
+      COMMAND_DIFF_LONG=( ${BASE_COMMAND[@]} --output=diff )
+      COMMAND_DIFF_SHORT=( ${BASE_COMMAND[@]} --output=diff --context=3 )
+      COMMAND_JSON=( ${BASE_COMMAND[@]} --output=json )
+      COMMAND_SIMPLE=( ${BASE_COMMAND[@]} --output=simple )
+
+      echo
+      echo "---"
+
+      ${COMMAND_DIFF_LONG[@]} > "helm-diff.long"
+
+      echo
+      echo "---"
+
+      ${COMMAND_DIFF_SHORT[@]} | tee "helm-diff.short"
+
+      echo
+      echo "---"
+
+      ${COMMAND_JSON[@]} | tee "helm-diff.json"
+
+      echo
+      echo "---"
+
+      ${COMMAND_SIMPLE[@]} | tee "helm-diff.simple"
+
+      echo
+      echo "---"
+
+  allow_failure: true
+
+  artifacts:
+    name: "${CI_JOB_NAME}@${CI_COMMIT_REF_NAME}"
+    paths:
+      - helm-diff.*

--- a/terraform.yml
+++ b/terraform.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/terraform.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/terraform.yml"
 
 cache:
   key: ${CI_PIPELINE_ID}

--- a/test-terraform-security.yml
+++ b/test-terraform-security.yml
@@ -1,7 +1,7 @@
 # The following is commented because it is already included by terraform.yml
 # and most often you want to include terraform along with security
 # include:
-#   - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/terraform.yml'
+#   - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/terraform.yml'
 
 test:terraform-security:
   extends: .terraform-security

--- a/test-unit-go.yml
+++ b/test-unit-go.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/test-unit.yml"
 
 test:unit:go:
   extends: .test:unit

--- a/test-unit-python.yml
+++ b/test-unit-python.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.6.0/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.7.0/templates/test-unit.yml"
 
 test:unit:python:
   extends: .test:unit


### PR DESCRIPTION
These changes add Job Templates for the Helm-Diff.
Helm-Diff is based on the following Helm Plugin: https://github.com/databus23/helm-diff.
The output of Helm-Diff Jobs are the actual differences between the last Helm Release and the current changes.

When one of the following templates will be used/imported, `helm-quality`, `helm-regional` or `helm-multiregion`, a Helm-Diff Job will automatically start, in the `test` stage, if certain conditions are met, per each environment (`quality`, `production-europe`, `production-america` and `production-asia`), depending on the type of Helm Template used -- i.e. `quality`, `regional` or `multiregion`.
Condition: The Helm-Diff Jobs will only run at Merge Requests to the `master` branch, only if the variable `ENABLE_HELM_DIFF` is set to `true`.

Example: If in the GitLab-CI Pipeline is used the `helm-regional` template and the `ENABLE_HELM_DIFF` variable is set to `true`, at each Merge Request to the `master` branch, for `quality` and `production` (i.e. which is the `production-europe`), 2 Helm-Diff Job will run, in the `test` stage, per each environment.