### PR TITLE
Add Fullstack Deployment Templates

### DIFF
--- a/bucket-production.yml
+++ b/bucket-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/bucket-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/bucket-quality.yml'
 
 deploy:production:
   extends: .deploy

--- a/bucket-quality.yml
+++ b/bucket-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/bucket.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/bucket.yml'
 
 deploy:quality:
   extends: .deploy

--- a/cloudrun-production.yml
+++ b/cloudrun-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/cloudrun-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/cloudrun-quality.yml'
 
 deploy:production:
   extends: deploy:quality

--- a/cloudrun-quality.yml
+++ b/cloudrun-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/cloudrun.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/cloudrun.yml'
 
 deploy:quality:
   extends: .cloudrun:deploy

--- a/dataflow-production.yml
+++ b/dataflow-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/dataflow-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/dataflow-quality.yml'
 
 deploy:production:dataflow:
   extends: .deploy:dataflow

--- a/dataflow-quality.yml
+++ b/dataflow-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/dataflow.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/dataflow.yml'
 
 deploy:quality:dataflow:
   extends: .deploy:dataflow

--- a/docker.yml
+++ b/docker.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/docker.yml"
 
 build:
   stage: build

--- a/helm-fullstack-multiregion.yml
+++ b/helm-fullstack-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/helm-fullstack-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/helm-fullstack-quality.yml"
 
 # EUROPE
 

--- a/helm-fullstack-multiregion.yml
+++ b/helm-fullstack-multiregion.yml
@@ -1,0 +1,543 @@
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/helm-fullstack-quality.yml"
+
+# EUROPE
+
+deploy:helm:api:production:europe:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    DOMAIN: ${DOMAIN_API_PRODUCTION_EUROPE}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_EUROPE}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-europe/api"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_API_EUROPE}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_API_PRODUCTION_EUROPE" "DOMAIN_API_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+deploy:helm:web:production:europe:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION_EUROPE}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_EUROPE}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-europe/web"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_WEB_EUROPE}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_WEB_PRODUCTION_EUROPE" "DOMAIN_WEB_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+verify:api:production:europe:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_EUROPE}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_API_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+verify:web:production:europe:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_EUROPE}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_WEB_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+helm:diff:api:production:europe:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    DOMAIN: ${DOMAIN_API_PRODUCTION_EUROPE}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_EUROPE}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-europe/api"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_API_EUROPE}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_API_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+helm:diff:web:production:europe:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_EUROPE}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_EUROPE}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_EUROPE}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION_EUROPE}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION_EUROPE}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_EUROPE}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-europe/web"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_WEB_EUROPE}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_EUROPE" "CLUSTER_NAME_PRODUCTION_EUROPE" "CLUSTER_ZONE_PRODUCTION_EUROPE" "NAMESPACE_WEB_PRODUCTION_EUROPE"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+# AMERICA
+
+deploy:helm:api:production:america:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    DOMAIN: ${DOMAIN_API_PRODUCTION_AMERICA}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_AMERICA}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-america/api"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_API_AMERICA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_API_PRODUCTION_AMERICA" "DOMAIN_API_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+deploy:helm:web:production:america:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION_AMERICA}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_AMERICA}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-america/web"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_WEB_AMERICA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_WEB_PRODUCTION_AMERICA" "DOMAIN_WEB_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+verify:api:production:america:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_AMERICA}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_API_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+verify:web:production:america:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_AMERICA}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_WEB_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+helm:diff:api:production:america:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    DOMAIN: ${DOMAIN_API_PRODUCTION_AMERICA}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_AMERICA}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-america/api"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_API_AMERICA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_API_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+helm:diff:web:production:america:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_AMERICA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_AMERICA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_AMERICA}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION_AMERICA}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION_AMERICA}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_AMERICA}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-america/web"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_WEB_AMERICA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_AMERICA" "CLUSTER_NAME_PRODUCTION_AMERICA" "CLUSTER_ZONE_PRODUCTION_AMERICA" "NAMESPACE_WEB_PRODUCTION_AMERICA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+# ASIA
+
+deploy:helm:api:production:asia:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    DOMAIN: ${DOMAIN_API_PRODUCTION_ASIA}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_ASIA}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-asia/api"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_API_ASIA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_API_PRODUCTION_ASIA" "DOMAIN_API_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+deploy:helm:web:production:asia:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION_ASIA}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_ASIA}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-asia/web"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_WEB_ASIA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_WEB_PRODUCTION_ASIA" "DOMAIN_WEB_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+verify:api:production:asia:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_ASIA}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_API_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+verify:web:production:asia:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_ASIA}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_WEB_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+helm:diff:api:production:asia:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    DOMAIN: ${DOMAIN_API_PRODUCTION_ASIA}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION_ASIA}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-asia/api"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_API_ASIA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_API_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+helm:diff:web:production:asia:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION_ASIA}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION_ASIA}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION_ASIA}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION_ASIA}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION_ASIA}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION_ASIA}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production-asia/web"
+    ENVIRONMENT_PATH: ${ENVIRONMENT_PATH_WEB_ASIA}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION_ASIA" "CLUSTER_NAME_PRODUCTION_ASIA" "CLUSTER_ZONE_PRODUCTION_ASIA" "NAMESPACE_WEB_PRODUCTION_ASIA"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'

--- a/helm-fullstack-quality.yml
+++ b/helm-fullstack-quality.yml
@@ -1,7 +1,7 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/docker.yml"
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/helm.yml"
 
 deploy:helm:api:quality:
   extends: .deploy:quality:helm

--- a/helm-fullstack-quality.yml
+++ b/helm-fullstack-quality.yml
@@ -1,0 +1,184 @@
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/helm.yml"
+
+deploy:helm:api:quality:
+  extends: .deploy:quality:helm
+
+  variables:
+    CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
+    GOOGLE_KEY: ${GOOGLE_KEY_API_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    DOMAIN: ${DOMAIN_API_QUALITY}
+    SECRET_YAML: ${SECRET_YAML_API_QUALITY}
+    NAMESPACE: ${NAMESPACE_API_QUALITY}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: quality
+    ENVIRONMENT_NAME: "quality/api"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_API_QUALITY" "DOMAIN_API_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - master
+
+deploy:helm:web:quality:
+  extends: .deploy:quality:helm
+
+  variables:
+    CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    DOMAIN: ${DOMAIN_WEB_QUALITY}
+    SECRET_YAML: ${SECRET_YAML_WEB_QUALITY}
+    NAMESPACE: ${NAMESPACE_WEB_QUALITY}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: quality
+    ENVIRONMENT_NAME: "quality/web"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_WEB_QUALITY" "DOMAIN_WEB_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - master
+
+verify:api:quality:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    NAMESPACE: ${NAMESPACE_API_QUALITY}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_API_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - master
+
+verify:web:quality:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    NAMESPACE: ${NAMESPACE_WEB_QUALITY}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_WEB_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - master
+
+helm:diff:api:quality:
+  extends: .helm:diff
+
+  variables:
+    CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
+    GOOGLE_KEY: ${GOOGLE_KEY_API_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    DOMAIN: ${DOMAIN_API_QUALITY}
+    SECRET_YAML: ${SECRET_YAML_API_QUALITY}
+    NAMESPACE: ${NAMESPACE_API_QUALITY}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: quality
+    ENVIRONMENT_NAME: "quality/api"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_API_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+helm:diff:web:quality:
+  extends: .helm:diff
+
+  variables:
+    CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_QUALITY}
+    CLUSTER_NAME: ${CLUSTER_NAME_QUALITY}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_QUALITY}
+    DOMAIN: ${DOMAIN_WEB_QUALITY}
+    SECRET_YAML: ${SECRET_YAML_WEB_QUALITY}
+    NAMESPACE: ${NAMESPACE_WEB_QUALITY}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: quality
+    ENVIRONMENT_NAME: "quality/web"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_QUALITY" "CLUSTER_NAME_QUALITY" "CLUSTER_ZONE_QUALITY" "NAMESPACE_WEB_QUALITY"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'

--- a/helm-fullstack-regional.yml
+++ b/helm-fullstack-regional.yml
@@ -1,0 +1,177 @@
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/helm-fullstack-quality.yml"
+
+deploy:helm:api:production:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    DOMAIN: ${DOMAIN_API_PRODUCTION}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production/api"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_API_PRODUCTION" "DOMAIN_API_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+deploy:helm:web:production:
+  extends: .deploy:production:helm
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production/web"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_WEB_PRODUCTION" "DOMAIN_WEB_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+verify:api:production:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_API_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+verify:web:production:
+  extends: .verify
+
+  stage: verify
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_WEB_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  only:
+    - /^v.+$/i
+  except:
+    - branches
+
+helm:diff:api:production:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_API_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    DOMAIN: ${DOMAIN_API_PRODUCTION}
+    SECRET_YAML: ${SECRET_YAML_API_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_API_PRODUCTION}
+    APP_NAME: ${API_APP_NAME}
+    PART_OF: ${API_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production/api"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_API_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_API_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+
+helm:diff:web:production:
+  extends: .helm:diff
+
+  variables:
+    GOOGLE_KEY: ${GOOGLE_KEY_WEB_PRODUCTION}
+    CLUSTER_NAME: ${CLUSTER_NAME_PRODUCTION}
+    CLUSTER_ZONE: ${CLUSTER_ZONE_PRODUCTION}
+    DOMAIN: ${DOMAIN_WEB_PRODUCTION}
+    SECRET_YAML: ${SECRET_YAML_WEB_PRODUCTION}
+    NAMESPACE: ${NAMESPACE_WEB_PRODUCTION}
+    APP_NAME: ${WEB_APP_NAME}
+    PART_OF: ${WEB_PART_OF}
+    ENVIRONMENT: production
+    ENVIRONMENT_NAME: "production/web"
+
+  before_script:
+    - |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "GOOGLE_KEY_WEB_PRODUCTION" "CLUSTER_NAME_PRODUCTION" "CLUSTER_ZONE_PRODUCTION" "NAMESPACE_WEB_PRODUCTION"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+  rules:
+    - if: '$ENABLE_HELM_DIFF == "true" && $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'

--- a/helm-fullstack-regional.yml
+++ b/helm-fullstack-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/helm-fullstack-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/helm-fullstack-quality.yml"
 
 deploy:helm:api:production:
   extends: .deploy:production:helm

--- a/helm-multiregion.yml
+++ b/helm-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/helm-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/helm-quality.yml"
 
 # EUROPE
 

--- a/helm-only-internal.yml
+++ b/helm-only-internal.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/helm.yml"
 
 deploy:internal:helm:
   extends: .deploy:internal:helm

--- a/helm-only-multiregion.yml
+++ b/helm-only-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/helm-only-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/helm-only-quality.yml"
 
 # EUROPE
 deploy:production:europe:helm:

--- a/helm-only-quality.yml
+++ b/helm-only-quality.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/helm.yml"
 
 deploy:quality:helm:
   extends: .deploy:quality:helm

--- a/helm-only-quality.yml
+++ b/helm-only-quality.yml
@@ -1,8 +1,10 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/helm.yml"
 
 deploy:quality:helm:
+  extends: .deploy:quality:helm
+
   variables:
     CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
     GOOGLE_KEY: ${GOOGLE_KEY_QUALITY}

--- a/helm-only-regional.yml
+++ b/helm-only-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/helm-only-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/helm-only-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/helm-quality.yml
+++ b/helm-quality.yml
@@ -1,7 +1,7 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/docker.yml"
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/helm.yml"
 
 deploy:quality:helm:
   extends: .deploy:quality:helm

--- a/helm-quality.yml
+++ b/helm-quality.yml
@@ -1,9 +1,11 @@
 ---
 include:
   - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/docker.yml"
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/helm.yml"
 
 deploy:quality:helm:
+  extends: .deploy:quality:helm
+
   variables:
     CI_COMMIT_TAG: ${CI_COMMIT_SHORT_SHA}
     GOOGLE_KEY: ${GOOGLE_KEY_QUALITY}

--- a/helm-regional.yml
+++ b/helm-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/helm-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/helm-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/kubernetes-multiregion.yml
+++ b/kubernetes-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/kubernetes-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/kubernetes-quality.yml"
 
 # EUROPE
 deploy:production:europe:image:

--- a/kubernetes-quality.yml
+++ b/kubernetes-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/kubernetes.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/kubernetes.yml'
 
 deploy:quality:image:
   extends: .deploy:image

--- a/kubernetes-regional.yml
+++ b/kubernetes-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/kubernetes-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/kubernetes-quality.yml'
 
 deploy:production:image:
   extends: .deploy:image

--- a/kubernetes-task-multiregion.yml
+++ b/kubernetes-task-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/kubernetes-task-quality.yml'
 
 task:production:europe:
   extends: .task

--- a/kubernetes-task-production.yml
+++ b/kubernetes-task-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/kubernetes-task-quality.yml'
 
 task:production:
   extends: .task

--- a/kubernetes-task-quality.yml
+++ b/kubernetes-task-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/kubernetes-task.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/kubernetes-task.yml'
 
 task:quality:
   extends: .task

--- a/lint-generic.yml
+++ b/lint-generic.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/lint.yml"
 
 lint:
   extends: .lint

--- a/lint-generic.yml
+++ b/lint-generic.yml
@@ -1,0 +1,14 @@
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/templates/lint.yml"
+
+lint:
+  extends: .lint
+
+  image: "${CI_REGISTRY_IMAGE}/${APP_LINT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}"
+
+  variables:
+    GIT_STRATEGY: none
+
+  script:
+    - echo "<RUN_LINTING_COMMAND>"

--- a/lint-go.yml
+++ b/lint-go.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/lint.yml"
 
 lint:go:
   extends: .lint

--- a/lint-javascript.yml
+++ b/lint-javascript.yml
@@ -1,13 +1,13 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/lint.yml"
 
 lint:eslint:
   extends: .lint
 
   image: "${CI_REGISTRY_IMAGE}/${APP_ESLINT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}"
 
-  script: 
+  script:
     - cd /app/src && pnpm run eslint-check
 
 lint:prettier:
@@ -15,5 +15,5 @@ lint:prettier:
 
   image: "${CI_REGISTRY_IMAGE}/${APP_PRETTIER_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}"
 
-  script: 
+  script:
     - cd /app/src && pnpm run prettier-check

--- a/lint-python.yml
+++ b/lint-python.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/lint.yml"
 
 lint:python:
   extends: .lint

--- a/lint-typescript.yml
+++ b/lint-typescript.yml
@@ -1,11 +1,11 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/lint.yml"
 
 lint:typecheck:
   extends: .lint
 
   image: "${CI_REGISTRY_IMAGE}/${APP_TYPECHECK_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}"
 
-  script: 
+  script:
     - cd /app/src && pnpm run typecheck

--- a/sast.yml
+++ b/sast.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/sast.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/sast.yml"
 
 sast:
   extends: .sast

--- a/sentry-fullstack.yml
+++ b/sentry-fullstack.yml
@@ -1,0 +1,39 @@
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/sentry.yml"
+
+sentry:api:release:set:
+  extends: .sentry:release:set
+
+  variables:
+    SENTRY_PROJECT: ${SENTRY_API_PROJECT}
+
+sentry:web:release:set:
+  extends: .sentry:release:set
+
+  variables:
+    SENTRY_PROJECT: ${SENTRY_WEB_PROJECT}
+
+sentry:api:release:finalize:
+  extends: .sentry:release:finalize
+
+  variables:
+    SENTRY_PROJECT: ${SENTRY_API_PROJECT}
+
+sentry:web:release:finalize:
+  extends: .sentry:release:finalize
+
+  variables:
+    SENTRY_PROJECT: ${SENTRY_WEB_PROJECT}
+
+sentry:api:notify:
+  extends: .sentry:notify
+
+  variables:
+    SENTRY_PROJECT: ${SENTRY_API_PROJECT}
+
+sentry:web:notify:
+  extends: .sentry:notify
+
+  variables:
+    SENTRY_PROJECT: ${SENTRY_WEB_PROJECT}

--- a/sentry-fullstack.yml
+++ b/sentry-fullstack.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/sentry.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/sentry.yml"
 
 sentry:api:release:set:
   extends: .sentry:release:set

--- a/sentry.yml
+++ b/sentry.yml
@@ -1,69 +1,12 @@
-.sentry:
-  image: jobtomelabs/sentry-cli-bash:v1.1.0
-  only:
-    - /^v.+$/i
-    - master
-    - merge_requests
-  allow_failure: true
-  when: on_success
-  script:
-    - &check-set-variables |
-      # CHECK VARIABLES PHASE
-      for var in "SENTRY_AUTH_TOKEN" "SENTRY_URL" "SENTRY_ORG" "SENTRY_PROJECT"; do
-          if [ -z "${!var}" ]; then
-            echo "Missing '${var}' variable!"
-            exit 1
-          fi
-      done
-
-      ENVIRONMENT="production"
-      if [ -z "${CI_COMMIT_TAG}" ]; then
-        CI_COMMIT_TAG=$(git describe --tags --always)
-        ENVIRONMENT="quality"
-      fi
-
-      sentry-cli info
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/sentry.yml"
 
 sentry:release:set:
-  extends: .sentry
-  stage: build
-  script:
-    - *check-set-variables
-    - |
-      #SET NEW RELEASE
-
-      sentry-cli releases new "${CI_COMMIT_TAG}"
-
-      if [ -n "${FEAT_SENTRY_SETCOMMITS}" ]; then
-        echo
-        echo "-> [INFO] variable 'FEAT_SENTRY_SETCOMMITS' for experimental feature enabled!"
-        echo
-        sentry-cli releases set-commits "${CI_COMMIT_TAG}" --auto
-      fi
-
-      echo "Sentry release set to ${CI_COMMIT_TAG}!"
-
+  extends: .sentry:release:set
 
 sentry:release:finalize:
-  extends: .sentry
-  stage: deploy
-  script:
-    - *check-set-variables
-    - |
-      #FINALISE RELEASE
-
-      sentry-cli releases finalize "${CI_COMMIT_TAG}"
-
-      echo "Sentry release finalized to ${CI_COMMIT_TAG}!"
+  extends: .sentry:release:finalize
 
 sentry:notify:
-  extends: .sentry
-  stage: notify
-  script:
-    - *check-set-variables
-    - |
-      #SET NEW DEPLOY
-
-      sentry-cli releases deploys "${CI_COMMIT_TAG}" new -e "${ENVIRONMENT}"
-
-      echo "Sentry was notified that release ${CI_COMMIT_TAG} was set for ${ENVIRONMENT}!"
+  extends: .sentry:notify

--- a/sentry.yml
+++ b/sentry.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/feat/add-fullstack-deployment-templates/templates/sentry.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/sentry.yml"
 
 sentry:release:set:
   extends: .sentry:release:set

--- a/serverless-multiregion.yml
+++ b/serverless-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/serverless-quality.yml'
 
 # EUROPE
 deploy:production:europe:

--- a/serverless-quality.yml
+++ b/serverless-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/serverless.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/serverless.yml'
 
 deploy:quality:
   extends: .serverless:deploy

--- a/serverless-regional.yml
+++ b/serverless-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/serverless-quality.yml'
 
 deploy:production:
   extends: .serverless:deploy

--- a/shell-job.yml
+++ b/shell-job.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/lint-shell.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/terraform.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/lint-shell.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/terraform.yml'
 
 job:shell:
   stage: deploy

--- a/ssh-production.yml
+++ b/ssh-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/ssh-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/ssh-quality.yml'
 
 ssh:production:
   extends: .ssh:exec

--- a/ssh-quality.yml
+++ b/ssh-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/ssh.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/ssh.yml'
 
 ssh:quality:
   extends: .ssh:exec

--- a/templates/helm.yml
+++ b/templates/helm.yml
@@ -188,7 +188,7 @@
 
       fi
 
-deploy:quality:helm:
+.deploy:quality:helm:
   extends: .helm:deploy
   only:
     - master

--- a/templates/sentry.yml
+++ b/templates/sentry.yml
@@ -1,0 +1,91 @@
+---
+.sentry:
+  image: jobtomelabs/sentry-cli-bash:v1.1.0
+
+  script:
+    - &check-set-variables |
+
+      # CHECK VARIABLES PHASE
+
+      for var in "SENTRY_AUTH_TOKEN" "SENTRY_URL" "SENTRY_ORG" "SENTRY_PROJECT"; do
+        if [ -z "${!var}" ]; then
+          echo "Missing '${var}' Variable!"
+          exit 1
+        fi
+      done
+
+      ENVIRONMENT="production"
+
+      if [ -z "${CI_COMMIT_TAG}" ]; then
+        CI_COMMIT_TAG=$(git describe --tags --always)
+        ENVIRONMENT="quality"
+      fi
+
+      sentry-cli info
+
+  only:
+    - merge_requests
+    - master
+    - /^v.+$/i
+
+  when: on_success
+
+  allow_failure: true
+
+.sentry:release:set:
+  extends: .sentry
+
+  stage: build
+
+  script:
+    - *check-set-variables
+
+    - |
+
+      # SET NEW RELEASE
+
+      sentry-cli releases new "${CI_COMMIT_TAG}"
+
+      if [ -n "${FEAT_SENTRY_SET_COMMITS}" ]; then
+
+        echo
+        echo "-> [INFO] Variable 'FEAT_SENTRY_SET_COMMITS' (Experimental Feature) Enabled!"
+        echo
+
+        sentry-cli releases set-commits "${CI_COMMIT_TAG}" --auto
+
+      fi
+
+      echo "Sentry Release set to '${CI_COMMIT_TAG}'!"
+
+.sentry:release:finalize:
+  extends: .sentry
+
+  stage: deploy
+
+  script:
+    - *check-set-variables
+
+    - |
+
+      # FINALIZE RELEASE
+
+      sentry-cli releases finalize "${CI_COMMIT_TAG}"
+
+      echo "Sentry Release finalized to '${CI_COMMIT_TAG}'!"
+
+.sentry:notify:
+  extends: .sentry
+
+  stage: notify
+
+  script:
+    - *check-set-variables
+
+    - |
+
+      # SET NEW DEPLOY
+
+      sentry-cli releases deploys "${CI_COMMIT_TAG}" new -e "${ENVIRONMENT}"
+
+      echo "Sentry Release '${CI_COMMIT_TAG}' set for '${ENVIRONMENT}'!"

--- a/terraform.yml
+++ b/terraform.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/terraform.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/terraform.yml"
 
 cache:
   key: ${CI_PIPELINE_ID}

--- a/test-terraform-security.yml
+++ b/test-terraform-security.yml
@@ -1,7 +1,7 @@
 # The following is commented because it is already included by terraform.yml
 # and most often you want to include terraform along with security
 # include:
-#   - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/terraform.yml'
+#   - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/terraform.yml'
 
 test:terraform-security:
   extends: .terraform-security

--- a/test-unit-generic.yml
+++ b/test-unit-generic.yml
@@ -1,0 +1,14 @@
+---
+include:
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/templates/test-unit.yml"
+
+test:unit:
+  extends: .test:unit
+
+  image: "${CI_REGISTRY_IMAGE}/${APP_TEST_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}"
+
+  variables:
+    GIT_STRATEGY: none
+
+  script:
+    - echo "<RUN_UNIT_TESTS_COMMAND>"

--- a/test-unit-generic.yml
+++ b/test-unit-generic.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.10.0/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/test-unit.yml"
 
 test:unit:
   extends: .test:unit

--- a/test-unit-go.yml
+++ b/test-unit-go.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/test-unit.yml"
 
 test:unit:go:
   extends: .test:unit

--- a/test-unit-javascript.yml
+++ b/test-unit-javascript.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/test-unit.yml"
 
 test:unit:js:
   extends: .test:unit

--- a/test-unit-python.yml
+++ b/test-unit-python.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.11.0/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.12.0/templates/test-unit.yml"
 
 test:unit:python:
   extends: .test:unit


### PR DESCRIPTION
This PR adds CI Templates for supporting Monorepo Projects -- i.e. Front-End and Back-End Apps are in the same repository.
By using these CI Templates, a single Pipeline will be able to run 2 Helm Releases (and dependencies -- e.g. Verify, Diffs, etc.), one for the Web (Front-End) App and another for the API (Back-End) App.