### PR TITLE
Fix Deployments Concurrency Issue

### DIFF
--- a/bucket-production.yml
+++ b/bucket-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/bucket-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/bucket-quality.yml'
 
 deploy:production:
   extends: .deploy

--- a/bucket-quality.yml
+++ b/bucket-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/bucket.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/bucket.yml'
 
 deploy:quality:
   extends: .deploy

--- a/cloudrun-production.yml
+++ b/cloudrun-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/cloudrun-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/cloudrun-quality.yml'
 
 deploy:production:
   extends: deploy:quality

--- a/cloudrun-quality.yml
+++ b/cloudrun-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/cloudrun.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/cloudrun.yml'
 
 deploy:quality:
   extends: .cloudrun:deploy

--- a/dataflow-production.yml
+++ b/dataflow-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/dataflow-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/dataflow-quality.yml'
 
 deploy:production:dataflow:
   extends: .deploy:dataflow

--- a/dataflow-quality.yml
+++ b/dataflow-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/dataflow.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/dataflow.yml'
 
 deploy:quality:dataflow:
   extends: .deploy:dataflow

--- a/docker.yml
+++ b/docker.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/docker.yml"
 
 build:
   stage: build

--- a/endpoints-multiregion.yml
+++ b/endpoints-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/endpoints-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/endpoints-quality.yml"
 
 # EUROPE
 

--- a/endpoints-quality.yml
+++ b/endpoints-quality.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/endpoints.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/endpoints.yml"
 
 endpoints:validate:quality:
   extends: .endpoints:validate

--- a/endpoints-regional.yml
+++ b/endpoints-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/endpoints-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/endpoints-quality.yml"
 
 endpoints:validate:production:
   extends: .endpoints:validate

--- a/endpoints-validate.yml
+++ b/endpoints-validate.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/endpoints.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/endpoints.yml"
 
 endpoints:validate:
   extends: .endpoints:validate

--- a/helm-fullstack-multiregion.yml
+++ b/helm-fullstack-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/helm-fullstack-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/helm-fullstack-quality.yml"
 
 # EUROPE
 

--- a/helm-fullstack-quality.yml
+++ b/helm-fullstack-quality.yml
@@ -1,7 +1,7 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/docker.yml"
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/helm.yml"
 
 deploy:helm:api:quality:
   extends: .deploy:quality:helm

--- a/helm-fullstack-regional.yml
+++ b/helm-fullstack-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/helm-fullstack-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/helm-fullstack-quality.yml"
 
 deploy:helm:api:production:
   extends: .deploy:production:helm

--- a/helm-multiregion.yml
+++ b/helm-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/helm-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/helm-quality.yml"
 
 # EUROPE
 

--- a/helm-only-internal.yml
+++ b/helm-only-internal.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/helm.yml"
 
 deploy:internal:helm:
   extends: .deploy:internal:helm

--- a/helm-only-multiregion.yml
+++ b/helm-only-multiregion.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/helm-only-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/helm-only-quality.yml"
 
 # EUROPE
 deploy:production:europe:helm:

--- a/helm-only-quality.yml
+++ b/helm-only-quality.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/helm.yml"
 
 deploy:quality:helm:
   extends: .deploy:quality:helm

--- a/helm-only-regional.yml
+++ b/helm-only-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/helm-only-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/helm-only-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/helm-quality.yml
+++ b/helm-quality.yml
@@ -1,7 +1,7 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/docker.yml"
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/helm.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/docker.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/helm.yml"
 
 deploy:quality:helm:
   extends: .deploy:quality:helm

--- a/helm-regional.yml
+++ b/helm-regional.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/helm-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/helm-quality.yml"
 
 deploy:production:helm:
   extends: .deploy:production:helm

--- a/kubernetes-multiregion.yml
+++ b/kubernetes-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/kubernetes-quality.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/kubernetes-quality.yml"
 
 # EUROPE
 deploy:production:europe:image:

--- a/kubernetes-quality.yml
+++ b/kubernetes-quality.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/docker.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/kubernetes.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/docker.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/kubernetes.yml'
 
 deploy:quality:image:
   extends: .deploy:image

--- a/kubernetes-regional.yml
+++ b/kubernetes-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/kubernetes-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/kubernetes-quality.yml'
 
 deploy:production:image:
   extends: .deploy:image

--- a/kubernetes-task-multiregion.yml
+++ b/kubernetes-task-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/kubernetes-task-quality.yml'
 
 task:production:europe:
   extends: .task

--- a/kubernetes-task-production.yml
+++ b/kubernetes-task-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/kubernetes-task-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/kubernetes-task-quality.yml'
 
 task:production:
   extends: .task

--- a/kubernetes-task-quality.yml
+++ b/kubernetes-task-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/kubernetes-task.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/kubernetes-task.yml'
 
 task:quality:
   extends: .task

--- a/lint-generic.yml
+++ b/lint-generic.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/lint.yml"
 
 lint:
   extends: .lint

--- a/lint-go.yml
+++ b/lint-go.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/lint.yml"
 
 lint:go:
   extends: .lint

--- a/lint-javascript.yml
+++ b/lint-javascript.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/lint.yml"
 
 lint:eslint:
   extends: .lint

--- a/lint-python.yml
+++ b/lint-python.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/lint.yml"
 
 lint:python:
   extends: .lint

--- a/lint-typescript.yml
+++ b/lint-typescript.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/lint.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/lint.yml"
 
 lint:typecheck:
   extends: .lint

--- a/sast.yml
+++ b/sast.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/sast.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/sast.yml"
 
 sast:
   extends: .sast

--- a/sentry-fullstack.yml
+++ b/sentry-fullstack.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/sentry.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/sentry.yml"
 
 sentry:api:release:set:
   extends: .sentry:release:set

--- a/sentry.yml
+++ b/sentry.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/sentry.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/sentry.yml"
 
 sentry:release:set:
   extends: .sentry:release:set

--- a/serverless-multiregion.yml
+++ b/serverless-multiregion.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/serverless-quality.yml'
 
 # EUROPE
 deploy:production:europe:

--- a/serverless-quality.yml
+++ b/serverless-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/serverless.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/serverless.yml'
 
 deploy:quality:
   extends: .serverless:deploy

--- a/serverless-regional.yml
+++ b/serverless-regional.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/serverless-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/serverless-quality.yml'
 
 deploy:production:
   extends: .serverless:deploy

--- a/shell-job.yml
+++ b/shell-job.yml
@@ -1,6 +1,6 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/lint-shell.yml'
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/terraform.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/lint-shell.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/terraform.yml'
 
 job:shell:
   stage: deploy

--- a/ssh-production.yml
+++ b/ssh-production.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/ssh-quality.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/ssh-quality.yml'
 
 ssh:production:
   extends: .ssh:exec

--- a/ssh-quality.yml
+++ b/ssh-quality.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/ssh.yml'
+  - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/ssh.yml'
 
 ssh:quality:
   extends: .ssh:exec

--- a/terraform.yml
+++ b/terraform.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/terraform.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/terraform.yml"
 
 cache:
   key: ${CI_PIPELINE_ID}

--- a/test-terraform-security.yml
+++ b/test-terraform-security.yml
@@ -1,7 +1,7 @@
 # The following is commented because it is already included by terraform.yml
 # and most often you want to include terraform along with security
 # include:
-#   - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/terraform.yml'
+#   - remote: 'https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/terraform.yml'
 
 test:terraform-security:
   extends: .terraform-security

--- a/test-unit-generic.yml
+++ b/test-unit-generic.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/test-unit.yml"
 
 test:unit:
   extends: .test:unit

--- a/test-unit-go.yml
+++ b/test-unit-go.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/test-unit.yml"
 
 test:unit:go:
   extends: .test:unit

--- a/test-unit-javascript.yml
+++ b/test-unit-javascript.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/test-unit.yml"
 
 test:unit:js:
   extends: .test:unit

--- a/test-unit-python.yml
+++ b/test-unit-python.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.13.2/templates/test-unit.yml"
+  - remote: "https://raw.githubusercontent.com/jobtome-labs/ci-templates/v3.14.0/templates/test-unit.yml"
 
 test:unit:python:
   extends: .test:unit


### PR DESCRIPTION
In case of concurrent pipelines with jobs to deploy to the same environment (e.g. `quality`, `production-europe`, etc.), the changes this PR adds will make so that the most recent pipeline will wait for the previous one to finish and only after that start.